### PR TITLE
gitattributes file to track zip files with lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+ # Archives
+*.zip filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Adding a .gitattributes file to track zip files under lfs

Testing:
Made sure the added zip files are tracked under lfs
![image](https://user-images.githubusercontent.com/81144760/227502022-c55db89b-5815-46d0-a717-eb80d6ca1108.png)
